### PR TITLE
feat: set buffer filetype to `shellbot`

### DIFF
--- a/chatgpt.lua
+++ b/chatgpt.lua
@@ -158,6 +158,7 @@ function ChatGPTInit()
   vim.api.nvim_buf_set_option(bufnr, 'buftype', 'nofile')
   vim.api.nvim_buf_set_option(bufnr, 'bufhidden', 'hide')
   vim.api.nvim_buf_set_option(bufnr, 'swapfile', false)
+  vim.api.nvim_buf_set_option(bufnr, 'filetype', 'shellbot')
   add_transcript_header(winnr, bufnr, "USER", 0)
   local modes = { 'n', 'i' }
   for _, mode in ipairs(modes) do


### PR DESCRIPTION
This allows buffer-local mappings to be configured and other options to be set. For example, [I'm using it](https://github.com/wincent/wincent/blob/4d92864b29c9d4eac2c7f2ae2189086be5119f35/aspects/nvim/files/.config/nvim/ftplugin/shellbot.lua) to map `<M-CR>` to `ChatGPTSubmit()` (sadly, the default mapping of `<C-CR>` doesn't seem to work inside tmux, so something else is needed).