### PR TITLE
feat: add Vim healthcheck

### DIFF
--- a/shellbot/health.lua
+++ b/shellbot/health.lua
@@ -1,0 +1,16 @@
+local health = vim.health -- after: https://github.com/neovim/neovim/pull/18720
+  or require('health') -- before: v0.8.x
+
+return {
+  -- Run with `:checkhealth shellbot`
+  check = function()
+    local shellbot = vim.env['SHELLBOT']
+    if shellbot == nil then
+      health.warn('SHELLBOT environment variable is not set')
+    elseif vim.fn.executable(shellbot) ~= 1 then
+      health.warn('SHELLBOT (' .. vim.inspect(shellbot) .. ') is not executable')
+    else
+      health.ok('SHELLBOT environment variable is set to an executable')
+    end
+  end,
+}


### PR DESCRIPTION
As described in `:h health-dev`.

You can run it with `:checkhealth shellbot` (or just `:checkhealth` in order to run all health checks) and you'll see output like:

    ==============================================================================
    shellbot: require("shellbot.health").check()

    - WARNING SHELLBOT ("/Users/wincent/.config/nvim/pack/bundle/opt/shellbot/lua/target/release/shellbot") is not executable

or:

    ==============================================================================
    shellbot: require("shellbot.health").check()

    - OK SHELLBOT environment variable is set to an executable

Note the location and naming of the healthcheck module (`shellbot/health.lua`) is dictated by the conventions spelled out in `:h health-dev`.