### PR TITLE
docs: fix formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@ AI assistants are transformational for programmers. However, ChatGPT 4 is also r
 
 ## Rust program
 The Rust program can be built with `cargo build`. It expects an `OPENAI_API_KEY` and/or an `ANTHROPIC_API_KEY` environment variable. If both keys are provided, Anthropic is used. The Rust program can take two kinds of input, read from stdin:
-1. Raw input
-In this case, a System prompt is provided in the compiled code
-2. Transcript
-The Rust program also accepts a homegrown "transcript" format in which transcript sections are delineated by lines which look like this
+1. **Raw input:** In this case, a System prompt is provided in the compiled code
+2. **Transcript:** The Rust program also accepts a homegrown "transcript" format in which transcript sections are delineated by lines which look like this
 
 ```
 ===USER===


### PR DESCRIPTION
Originally sent as:

- https://github.com/wolffiex/shellbot/pull/1

Now rebased to fix merge conflict.

---

Despite the newline in the source, GitHub renders each of these numbered list items all on one line.

User markup to make the separation obvious.

#### Before

![75y3CRsh](https://github.com/wolffiex/shellbot/assets/7074/45edb7c2-b8d4-4432-b7d2-1f4fe5d1a245)

#### After

![XMepgIQC](https://github.com/wolffiex/shellbot/assets/7074/92018436-b153-438a-8d90-b03cd4a37a2c)