### PR TITLE
feat: refactor health check to allow spaces in SHELLBOT

### DIFF
--- a/shellbot/health.lua
+++ b/shellbot/health.lua
@@ -7,10 +7,15 @@ return {
     local shellbot = vim.env['SHELLBOT']
     if shellbot == nil then
       health.warn('SHELLBOT environment variable is not set')
-    elseif vim.fn.executable(shellbot) ~= 1 then
-      health.warn('SHELLBOT (' .. vim.inspect(shellbot) .. ') is not executable')
     else
-      health.ok('SHELLBOT environment variable is set to an executable')
+      local executable = vim.fn.split(shellbot, ' ')[1]
+      if executable == nil then
+        health.warn('SHELLBOT environment variable is empty')
+      elseif vim.fn.executable(executable) ~= 1 then
+        health.warn('SHELLBOT (' .. vim.inspect(shellbot) .. ') is not executable')
+      else
+        health.ok('SHELLBOT environment variable is set to an executable')
+      end
     end
   end,
 }


### PR DESCRIPTION
In ef73bd45e07dc9669b20d97aa4b06200e7ea11f3 we added a support for a command-line argument that can be used to override the default prompt, but actually supplying an arguments means that the old `vim.fn.executable` check won't work.

The simplest fix is to just split on whitespace and check the first item to see if it's executable. This isn't perfect, because if somebody installed the executable at a path like `/My/Path With Spaces/bin/shellbot`, then we'd test `/My/Path` and report a false negative. But for the common case, this is still an improvement.