### PR TITLE
feat: cosmetic tweaks for Neovim

### DIFF
--- a/chatbot.lua
+++ b/chatbot.lua
@@ -4,9 +4,10 @@ local is_receiving = false
 local bot_cmd = os.getenv("SHELLBOT")
 local separator = "==="
 
+local nbsp = ' '
 local roles = {
-  USER = "◭🧑 " .. os.getenv('USER'),
-  ASSISTANT = "◮🤖 vimbot",
+  USER = " 🤓 «" .. os.getenv('USER') .. "»" .. nbsp,
+  ASSISTANT = " 🤖 «vimbot»" .. nbsp,
 }
 
 local buffer_sync_cursor = {}
@@ -95,9 +96,9 @@ function ChatBotSubmit()
   local function get_transcript()
     local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
     for i, line in ipairs(lines) do
-      if line:match("^◭") then -- '^' means start of line
+      if line:match("^ 🤓") then -- '^' means start of line
         lines[i] = separator .. "USER" .. separator
-      elseif line:match("^◮") then
+      elseif line:match("^ 🤖") then
         lines[i] = separator .. "ASSISTANT" .. separator
       end
     end

--- a/chatbot.lua
+++ b/chatbot.lua
@@ -6,8 +6,8 @@ local separator = "==="
 
 local nbsp = ' '
 local roles = {
-  USER = " 🤓 «" .. os.getenv('USER') .. "»" .. nbsp,
-  ASSISTANT = " 🤖 «vimbot»" .. nbsp,
+  USER = nbsp .. "🤓 «" .. os.getenv('USER') .. "»" .. nbsp,
+  ASSISTANT = nbsp .. "🤖 «vimbot»" .. nbsp,
 }
 
 local buffer_sync_cursor = {}
@@ -96,9 +96,9 @@ function ChatBotSubmit()
   local function get_transcript()
     local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
     for i, line in ipairs(lines) do
-      if line:match("^ 🤓") then -- '^' means start of line
+      if line:match('^' .. nbsp .. '🤓') then  -- '^' means start of line
         lines[i] = separator .. "USER" .. separator
-      elseif line:match("^ 🤖") then
+      elseif line:match('^' .. nbsp ..'🤖') then
         lines[i] = separator .. "ASSISTANT" .. separator
       end
     end


### PR DESCRIPTION
This is a draft for now because it would require bigger changes to directory layout in order to fully complete it. If you want me to make those changes, let me know and I can update.

## Before this PR

![bzVdcHNw](https://github.com/user-attachments/assets/e0711b55-ab44-4a39-bca4-e819e680a1bd)

## After this PR

![CgOfMjFx](https://github.com/user-attachments/assets/3f49c7bc-634b-4557-ab1c-52fddcde85ad)

## With a syntax file

![ESYUyda1](https://github.com/user-attachments/assets/b1d6d44d-674f-4c8a-aced-e7cfbf11e813)

---

That last screenshot shows what the non-breaking spaces are all about: they provide us with something we can conveniently syntax-highlight to make the headers stand out:

```lua
if vim.fn.exists('main_syntax') == 0 then
  if vim.fn.exists('b:current_syntax') == 1 then
    return
  end
  vim.g.main_syntax = 'shellbot'
elseif vim.fn.exists('b:current_syntax') == 1 and vim.b.current_syntax == 'shellbot' then
  return
end

vim.cmd('runtime! syntax/markdown.vim')

local cpo = vim.o.cpo

vim.cmd([[
  set cpo&vim
  syntax match ChatBotHeader /^ 🤓 .*/ containedin=ALL
  syntax match ChatBotHeader /^ 🤖 .*/ containedin=ALL
  highlight def link ChatBotHeader TermCursor
]])

vim.b.current_syntax = 'shellbot'
if vim.g.main_syntax == 'shellbot' then
  vim.api.nvim_del_var('main_syntax')
end
vim.o.cpo = cpo
```

So, why can't I include [the syntax file](https://github.com/wincent/wincent/blob/bf899fdd9a8247946cce8de78fb64095301ddcab/aspects/nvim/files/.config/nvim/syntax/shellbot.lua) in this PR? Because syntax files have to live under a `syntax` directory, but the repo doesn't have the right layout right now; ie. the current layout is:

```
<root>
├── Cargo.lock
├── Cargo.toml
├── LICENSE
├── README.md
├── chatbot.lua
├── shellbot
│   └── health.lua
├── shellbot.sh
└── src
    ├── anthropic.rs
    ├── api.rs
    ├── main.rs
    ├── openai.rs
    └── sse.rs
```

but the final layout would need to be something like:

```
<root>
├── Cargo.lock
├── Cargo.toml
├── LICENSE
├── README.md
└── lua
|   ├── chatbot.lua
|   └── shellbot
|       └── health.lua
└── syntax
|   └── shellbot.lua
├── shellbot.sh
└── src
    ├── anthropic.rs
    ├── api.rs
    ├── main.rs
    ├── openai.rs
    └── sse.rs
```

ie.

- move Neovim lua files into `lua` subdirectory; this is where Neovim expects to find Lua files such that they can be imported with `require('shellbot')`.
- create `syntax/shellbot.lua`; standard location for syntax files, automatically loaded when `shellbot` `'filetype'` is activated.