### PR TITLE
docs: fix outdated instruction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ If a transcript does not start with a System section, then the default System pr
 ## Lua script
 The included lua script can be copied to `.config/nvim/lua` and installed with something like 
 ```
-vim.cmd("command! ChatGPT lua require'chatgpt'.chatgpt()")
+vim.cmd("command! ChatBoT lua require'chatbot'.chatbot()")
 ```
 
 This command locates the Rust binary through the `SHELLBOT` environment variable. This should be set to the absolute path of the rust binary built in the step above.


### PR DESCRIPTION
Module was renamed in 919a92414c66ffdbb7856cc0342598d7a8fcc5c7, so these instructions are wrong now.